### PR TITLE
Add board post edit page

### DIFF
--- a/src/app/(content)/board/[category]/create/hook/use-board-form.ts
+++ b/src/app/(content)/board/[category]/create/hook/use-board-form.ts
@@ -9,9 +9,13 @@ import {
 
 interface UseBoardFormProps {
    userData: any
+   defaultValues?: Partial<BoardFormType>
 }
 
-export const useBoardForm = ({ userData }: UseBoardFormProps) => {
+export const useBoardForm = ({
+   userData,
+   defaultValues,
+}: UseBoardFormProps) => {
    const [showPassword, setShowPassword] = useState(false)
    const [isAuthenticated, setIsAuthenticated] = useState(false)
 
@@ -27,6 +31,7 @@ export const useBoardForm = ({ userData }: UseBoardFormProps) => {
          content: '',
          summary: '',
          thumbnail: '',
+         ...defaultValues,
       },
    })
 

--- a/src/app/(content)/board/[category]/create/ui/mark-down-editor.tsx
+++ b/src/app/(content)/board/[category]/create/ui/mark-down-editor.tsx
@@ -49,6 +49,7 @@ interface MarkDownEditorProps {
    setValue: UseFormSetValue<any>
    register: UseFormRegister<any>
    onImageUpload?: (base64Images: { name: string; data: string }[]) => void
+   initialValue?: string
 }
 const supabase = SupabaseBrowserClient()
 
@@ -57,8 +58,9 @@ const MarkDownEditor = ({
    setValue,
    register,
    onImageUpload,
+   initialValue = '',
 }: MarkDownEditorProps) => {
-   const [editorValue, setEditorValue] = React.useState<string>('')
+   const [editorValue, setEditorValue] = React.useState<string>(initialValue)
    const [tempImages, setTempImages] = React.useState<
       { name: string; data: string }[]
    >([])
@@ -67,7 +69,9 @@ const MarkDownEditor = ({
    const [isOpen, setIsOpen] = React.useState(false)
    React.useEffect(() => {
       register(name)
-   }, [register, name])
+      setValue(name, initialValue)
+      setEditorValue(initialValue)
+   }, [register, name, initialValue, setValue])
 
    React.useEffect(() => {
       if (onImageUpload) {

--- a/src/app/(content)/board/[category]/update/[id]/page.tsx
+++ b/src/app/(content)/board/[category]/update/[id]/page.tsx
@@ -1,8 +1,12 @@
 import { Metadata } from 'next'
+import { notFound, redirect } from 'next/navigation'
+import { SupabaseServerClient } from '@/shared/lib/supabase/supabase-server-client'
+import UpdatePostForm from '../ui'
 
 interface IParams {
    params: {
       id: string
+      category: string
    }
 }
 
@@ -12,7 +16,23 @@ export const metadata: Metadata = {
 }
 
 export default async function Update({ params }: IParams) {
-   const postId: string = params.id
+   const { id: postId, category } = params
 
-   return <></>
+   if (!category || !postId) {
+      redirect('/board/all')
+   }
+
+   const supabase = await SupabaseServerClient()
+
+   const { data: post, error } = await supabase
+      .from('posts')
+      .select('*')
+      .eq('id', postId)
+      .single()
+
+   if (error || !post) {
+      return notFound()
+   }
+
+   return <UpdatePostForm category={category} post={post} postId={postId} />
 }

--- a/src/app/(content)/board/[category]/update/hook/index.ts
+++ b/src/app/(content)/board/[category]/update/hook/index.ts
@@ -1,0 +1,1 @@
+export { useUpdatePost } from './use-update-post'

--- a/src/app/(content)/board/[category]/update/hook/use-update-post.ts
+++ b/src/app/(content)/board/[category]/update/hook/use-update-post.ts
@@ -1,0 +1,124 @@
+import { useToast } from '@/shared/hooks/use-toast'
+import { SupabaseBrowserClient } from '@/shared/lib/supabase/supabase-browser-client'
+import { compressImage } from '@/shared/utils/compress-image'
+import { markdownToSanitizedHTML } from '@/shared/utils/validators/board/formatSanized'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
+import dayjs from 'dayjs'
+import { useRouter } from 'next/navigation'
+import { useState } from 'react'
+import type { BoardFormType } from '../../create/schema/board-schema'
+
+const supabase = SupabaseBrowserClient()
+
+interface UseUpdatePostProps {
+   category: string
+   postId: string
+}
+
+export const useUpdatePost = ({ category, postId }: UseUpdatePostProps) => {
+   const router = useRouter()
+   const queryClient = useQueryClient()
+   const { toast } = useToast()
+   const [uploading, setUploading] = useState(false)
+
+   const uploadImageMutation = useMutation({
+      mutationFn: async (file: File) => {
+         const result = await compressImage(file, {
+            fileType: 'image/webp',
+            maxSizeMB: 0.1,
+            maxWidthOrHeight: 1920,
+         })
+
+         if (result.status === 'error') throw new Error('이미지 압축 실패')
+
+         const timestamp = dayjs().format('YYYYMMDDHHmmss')
+         const fileExtension = file.name.split('.').pop()?.toLowerCase()
+         const newFileName = `public/thumbnail_${timestamp}.${fileExtension}`
+
+         const { data, error } = await supabase.storage
+            .from('images')
+            .upload(newFileName, result.file, {
+               cacheControl: '3600',
+               upsert: false,
+               contentType: result.file.type,
+            })
+
+         if (error) throw error
+
+         const {
+            data: { publicUrl },
+         } = supabase.storage.from('images').getPublicUrl(data.path)
+
+         return publicUrl
+      },
+      onSuccess: () => {
+         setUploading(false)
+      },
+      onError: () => {
+         alert('이미지 업로드에 실패했습니다.')
+         setUploading(false)
+      },
+   })
+
+   const { mutate: updatePost, isPending: isSubmittingPost } = useMutation({
+      mutationFn: async (data: BoardFormType) => {
+         const markdownContent = data.content
+         const htmlContent = await markdownToSanitizedHTML(markdownContent)
+
+         const postData: any = {
+            title: data.title,
+            summary: data.summary,
+            thumbnail: data.thumbnail,
+            content: {
+               markdown: markdownContent,
+               html: htmlContent,
+            },
+         }
+
+         const { data: result, error } = await supabase
+            .from('posts')
+            .update(postData)
+            .eq('id', postId)
+
+         if (error) throw error
+         return result
+      },
+      onSuccess: () => {
+         queryClient.invalidateQueries({ queryKey: ['posts'] })
+         toast({
+            title: '성공',
+            description: '게시글이 수정되었습니다.',
+            duration: 3000,
+         })
+         router.push(`/board/${category}/${postId}`)
+      },
+      onError: (error) => {
+         toast({
+            variant: 'destructive',
+            title: '오류',
+            description: `수정 오류: ${error.message}`,
+            duration: 3000,
+         })
+      },
+   })
+
+   const handleImageUpload = async (e: React.ChangeEvent<HTMLInputElement>) => {
+      e.preventDefault()
+      const file = e.target.files?.[0]
+      if (!file) return
+      setUploading(true)
+      uploadImageMutation.mutate(file)
+   }
+
+   const onSubmit = (data: BoardFormType) => {
+      updatePost(data)
+   }
+
+   return {
+      uploading,
+      isSubmittingPost,
+      uploadImageMutation,
+      handleImageUpload,
+      onSubmit,
+   }
+}

--- a/src/app/(content)/board/[category]/update/ui/index.tsx
+++ b/src/app/(content)/board/[category]/update/ui/index.tsx
@@ -1,0 +1,139 @@
+'use client'
+
+import { Button } from '@/shared/shadcn/ui/button'
+import {
+   Form,
+   FormControl,
+   FormField,
+   FormItem,
+   FormMessage,
+} from '@/shared/shadcn/ui/form'
+import { Input } from '@/shared/shadcn/ui/input'
+import { Textarea } from '@/shared/shadcn/ui/textarea'
+import { useBoardForm } from '../../create/hook'
+import { useUpdatePost } from '../hook'
+import LoadingModal from '../../create/ui/loading-modal'
+import MarkDownEditor from '../../create/ui/mark-down-editor'
+import MarkDownTip from '../../create/ui/markdown-tip'
+import ThumbnailUpload from '../../create/ui/thumbnail-upload'
+
+interface Props {
+   category: string
+   post: any
+   postId: string
+}
+
+export default function UpdatePostForm({ category, post, postId }: Props) {
+   const { uploading, isSubmittingPost, uploadImageMutation, onSubmit } =
+      useUpdatePost({ category, postId })
+
+   const { form, setThumbnail } = useBoardForm({
+      userData: { user: true },
+      defaultValues: {
+         title: post.title || '',
+         content: post.content?.markdown || '',
+         summary: post.summary || '',
+         thumbnail: post.thumbnail || '',
+      },
+   })
+
+   const handleImageUpload = async (e: React.ChangeEvent<HTMLInputElement>) => {
+      e.preventDefault()
+      const file = e.target.files?.[0]
+      if (!file) return
+
+      uploadImageMutation.mutate(file, {
+         onSuccess: (publicUrl) => {
+            setThumbnail(publicUrl)
+         },
+      })
+   }
+
+   const thumbnailUrl = form.watch('thumbnail')
+
+   return (
+      <section className="w-full py-2">
+         <LoadingModal isOpen={isSubmittingPost} />
+         <Form {...form}>
+            <form
+               className="w-full flex flex-col gap-2"
+               onSubmit={form.handleSubmit(onSubmit)}
+            >
+               <FormField
+                  control={form.control}
+                  name="title"
+                  render={({ field }) => (
+                     <FormItem>
+                        <FormControl>
+                           <Input
+                              className="text-sm sm:text-base"
+                              placeholder="제목을 입력해주세요"
+                              {...field}
+                              disabled={isSubmittingPost}
+                           />
+                        </FormControl>
+                        <FormMessage />
+                     </FormItem>
+                  )}
+               />
+
+               <div className="flex justify-between gap-2 flex-wrap flex-1 w-full min-h-[80px]">
+                  <FormField
+                     control={form.control}
+                     name="summary"
+                     render={({ field }) => (
+                        <FormItem className="w-full max-w-[650px] min-w-[300px]">
+                           <FormControl>
+                              <Textarea
+                                 id="summary"
+                                 maxLength={155}
+                                 className="text-sm font-sans "
+                                 placeholder="요약"
+                                 {...field}
+                              />
+                           </FormControl>
+                        </FormItem>
+                     )}
+                  />
+                  <div className="flex flex-1 font-sans gap-2 items-center border w-full min-w-[300px] max-w-[650px] p-2 rounded-md">
+                     <div className="text-sm sm:text-base flex flex-col gap-1 w-full min-h-[80px] overflow-hidden">
+                        <h1 className="font-bold text-xl overflow-hidden text-ellipsis line-clamp-2 whitespace-pre-wrap text-[##3d00b3] dark:text-[#7EAAFF] min-h-[20px] break-words">
+                           {form.watch('title') || '제목 미리보기'}
+                        </h1>
+                        <p className="text-sm overflow-hidden text-ellipsis line-clamp-3 whitespace-pre-wrap text-[#767676] dark:text-[#CDCDCD] break-words">
+                           {form.watch('summary') || '요약내용 미리보기'}
+                        </p>
+                     </div>
+                     <ThumbnailUpload
+                        thumbnailUrl={thumbnailUrl}
+                        uploading={uploading}
+                        onImageUpload={handleImageUpload}
+                     />
+                  </div>
+               </div>
+               <MarkDownTip />
+               <MarkDownEditor
+                  name="content"
+                  setValue={form.setValue}
+                  register={form.register}
+                  initialValue={post.content?.markdown || ''}
+               />
+               <div className="flex gap-6 justify-end my-2 item">
+                  <Button
+                     type="button"
+                     size="lg"
+                     className="bg-gray-400 hover:bg-gray-500"
+                     onClick={() => window.history.back()}
+                     disabled={isSubmittingPost}
+                  >
+                     취소
+                  </Button>
+                  <Button size="lg" type="submit" disabled={isSubmittingPost}>
+                     수정 하기
+                  </Button>
+               </div>
+            </form>
+         </Form>
+      </section>
+   )
+}


### PR DESCRIPTION
## Summary
- add `initialValue` prop to Markdown editor
- support default values in board form hook
- implement update hooks and UI for editing board posts
- fetch post data on the new edit page

## Testing
- `npm run format`
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c18edc484832eb3827775d478e46a